### PR TITLE
[MI-3597] Moved the issue status field into filters section of modal

### DIFF
--- a/webapp/src/components/modals/channel_subscriptions/__snapshots__/edit_channel_subscription.test.tsx.snap
+++ b/webapp/src/components/modals/channel_subscriptions/__snapshots__/edit_channel_subscription.test.tsx.snap
@@ -491,45 +491,6 @@ exports[`components/EditChannelSubscription should match snapshot after fetching
           ]
         }
       />
-      <ReactSelectSetting
-        addValidate={[Function]}
-        isMulti={true}
-        label="Issue Status"
-        name="issue_status"
-        onChange={[Function]}
-        options={Array []}
-        removeValidate={[Function]}
-        theme={
-          Object {
-            "awayIndicator": "#ffbc42",
-            "buttonBg": "#166de0",
-            "buttonColor": "#ffffff",
-            "centerChannelBg": "#ffffff",
-            "centerChannelColor": "#3d3c40",
-            "codeTheme": "github",
-            "dndIndicator": "#f74343",
-            "errorTextColor": "#fd5960",
-            "linkColor": "#2389d7",
-            "mentionBg": "#ffffff",
-            "mentionBj": "#ffffff",
-            "mentionColor": "#145dbf",
-            "mentionHighlightBg": "#ffe577",
-            "mentionHighlightLink": "#166de0",
-            "newMessageSeparator": "#ff8800",
-            "onlineIndicator": "#06d6a0",
-            "sidebarBg": "#145dbf",
-            "sidebarHeaderBg": "#1153ab",
-            "sidebarHeaderTextColor": "#ffffff",
-            "sidebarText": "#ffffff",
-            "sidebarTextActiveBorder": "#579eff",
-            "sidebarTextActiveColor": "#ffffff",
-            "sidebarTextHoverBg": "#4578bf",
-            "sidebarUnreadText": "#ffffff",
-            "type": "Mattermost",
-          }
-        }
-        value={Array []}
-      />
       <ChannelSubscriptionFilters
         addValidate={[Function]}
         chosenIssueTypes={
@@ -875,6 +836,20 @@ exports[`components/EditChannelSubscription should match snapshot after fetching
                   "value": "5",
                 },
               ],
+            },
+            Object {
+              "issueTypes": Array [
+                Object {
+                  "id": "10004",
+                  "name": "10004",
+                },
+              ],
+              "key": "status",
+              "name": "Status",
+              "schema": Object {
+                "type": "array",
+              },
+              "values": Array [],
             },
           ]
         }

--- a/webapp/src/components/modals/channel_subscriptions/channel_subscription_filter.tsx
+++ b/webapp/src/components/modals/channel_subscriptions/channel_subscription_filter.tsx
@@ -202,7 +202,7 @@ export default class ChannelSubscriptionFilter extends React.PureComponent<Props
         if (field.key === FIELD_KEY_STATUS) {
             inclusionSelectOptions = [
                 {label: 'Include', value: FilterFieldInclusion.INCLUDE_ANY},
-                {label: 'Empty', value: FilterFieldInclusion.EMPTY},
+                {label: 'Exclude', value: FilterFieldInclusion.EXCLUDE_ANY},
             ];
         }
 

--- a/webapp/src/components/modals/channel_subscriptions/channel_subscription_filter.tsx
+++ b/webapp/src/components/modals/channel_subscriptions/channel_subscription_filter.tsx
@@ -5,7 +5,7 @@ import {Theme} from 'mattermost-redux/types/preferences';
 import ReactSelectSetting from 'components/react_select_setting';
 import JiraEpicSelector from 'components/data_selectors/jira_epic_selector';
 
-import {isEpicLinkField, isMultiSelectField, isLabelField, isSecurityLevelField} from 'utils/jira_issue_metadata';
+import {isEpicLinkField, isMultiSelectField, isLabelField, isSecurityLevelField, FIELD_KEY_STATUS} from 'utils/jira_issue_metadata';
 import {FilterField, FilterValue, ReactSelectOption, IssueMetadata, IssueType, FilterFieldInclusion} from 'types/model';
 import ConfirmModal from 'components/confirm_modal';
 import JiraAutoCompleteSelector from 'components/data_selectors/jira_autocomplete_selector';
@@ -195,6 +195,13 @@ export default class ChannelSubscriptionFilter extends React.PureComponent<Props
             inclusionSelectOptions = [
                 {label: 'Include', value: FilterFieldInclusion.INCLUDE_ANY},
                 {label: 'Include All', value: FilterFieldInclusion.INCLUDE_ALL},
+                {label: 'Empty', value: FilterFieldInclusion.EMPTY},
+            ];
+        }
+
+        if (field.key === FIELD_KEY_STATUS) {
+            inclusionSelectOptions = [
+                {label: 'Include', value: FilterFieldInclusion.INCLUDE_ANY},
                 {label: 'Empty', value: FilterFieldInclusion.EMPTY},
             ];
         }

--- a/webapp/src/components/modals/channel_subscriptions/edit_channel_subscription.tsx
+++ b/webapp/src/components/modals/channel_subscriptions/edit_channel_subscription.tsx
@@ -195,7 +195,7 @@ export default class EditChannelSubscription extends PureComponent<Props, State>
 
         let conflictingFields = null;
         if (finalValue.length > this.state.filters.issue_types.length) {
-            const filterFields = getCustomFieldFiltersForProjects(this.state.jiraIssueMetadata, this.state.filters.projects);
+            const filterFields = getCustomFieldFiltersForProjects(this.state.jiraIssueMetadata, this.state.filters.projects, this.state.issue_statuses, this.state.filters.issue_types);
             conflictingFields = getConflictingFields(
                 filterFields,
                 finalValue,
@@ -257,7 +257,7 @@ export default class EditChannelSubscription extends PureComponent<Props, State>
                 state.getMetaDataErr = `The project ${projectKeys[0]} is unavailable. Please contact your system administrator.`;
             }
 
-            const filterFields = getCustomFieldFiltersForProjects(jiraIssueMetadata, this.state.filters.projects);
+            const filterFields = getCustomFieldFiltersForProjects(jiraIssueMetadata, this.state.filters.projects, this.state.issue_statuses, this.state.filters.issue_types);
             for (const v of this.state.filters.fields) {
                 if (!filterFields.find((f) => f.key === v.key)) {
                     state.error = 'A field in this subscription has been removed from Jira, so the subscription is invalid. When this form is submitted, the configured field will be removed from the subscription to make the subscription valid again.';
@@ -366,7 +366,7 @@ export default class EditChannelSubscription extends PureComponent<Props, State>
             return;
         }
 
-        const filterFields = getCustomFieldFiltersForProjects(this.state.jiraIssueMetadata, this.state.filters.projects);
+        const filterFields = getCustomFieldFiltersForProjects(this.state.jiraIssueMetadata, this.state.filters.projects, this.state.issue_statuses, this.state.filters.issue_types);
         const configuredFields = this.state.filters.fields.concat([]);
         for (const v of this.state.filters.fields) {
             if (!filterFields.find((f) => f.key === v.key)) {
@@ -413,10 +413,9 @@ export default class EditChannelSubscription extends PureComponent<Props, State>
 
         const issueTypes = getIssueTypes(this.state.jiraIssueMetadata, this.state.filters.projects[0]);
         const issueOptions = issueTypes.map((it) => ({label: it.name, value: it.id}));
-        const issueStatusOptions = this.state.issue_statuses ? this.state.issue_statuses.map((s) => ({label: s.name, value: s.id})) : [];
 
         const customFields = getCustomFieldValuesForEvents(this.state.jiraIssueMetadata, this.state.filters.projects);
-        const filterFields = getCustomFieldFiltersForProjects(this.state.jiraIssueMetadata, this.state.filters.projects);
+        const filterFields = getCustomFieldFiltersForProjects(this.state.jiraIssueMetadata, this.state.filters.projects, this.state.issue_statuses, this.state.filters.issue_types);
 
         const eventOptions = JiraEventOptions.concat(customFields);
 
@@ -471,18 +470,6 @@ export default class EditChannelSubscription extends PureComponent<Props, State>
                             removeValidate={this.validator.removeComponent}
                         />
                         {conflictingErrorComponent}
-                        <ReactSelectSetting
-                            name={'issue_status'}
-                            label={'Issue Status'}
-                            onChange={this.handleIssueStatusChange}
-                            options={issueStatusOptions}
-                            isMulti={true}
-                            theme={this.props.theme}
-                            value={issueStatusOptions && issueStatusOptions.filter((option) => this.state.filters.issue_statuses.includes(option.value))}
-                            addValidate={this.validator.addComponent}
-                            removeValidate={this.validator.removeComponent}
-                        />
-                        {getIssueStatusesErrorComponent}
                         <ChannelSubscriptionFilters
                             fields={filterFields}
                             values={this.state.filters.fields}
@@ -495,6 +482,7 @@ export default class EditChannelSubscription extends PureComponent<Props, State>
                             instanceID={this.state.instanceID}
                             securityLevelEmptyForJiraSubscriptions={this.props.securityLevelEmptyForJiraSubscriptions}
                         />
+                        {getIssueStatusesErrorComponent}
                         <div>
                             <label className='control-label margin-bottom'>
                                 {'Approximate JQL Output'}

--- a/webapp/src/utils/jira_issue_metadata.tsx
+++ b/webapp/src/utils/jira_issue_metadata.tsx
@@ -16,6 +16,7 @@ import {
     FilterFieldInclusion,
     JiraFieldCustomTypeEnums,
     JiraFieldTypeEnums,
+    Status,
 } from 'types/model';
 
 type FieldWithInfo = JiraField & {
@@ -24,6 +25,8 @@ type FieldWithInfo = JiraField & {
     validIssueTypes: IssueTypeIdentifier[];
     issueTypeMeta: IssueTypeIdentifier;
 }
+
+export const FIELD_KEY_STATUS = 'status';
 
 // This is a replacement for the Array.flat() function which will be polyfilled by Babel
 // in our 5.16 release. Remove this and replace with .flat() then.
@@ -185,7 +188,7 @@ function isValidFieldForFilter(field: JiraField): boolean {
     (type === 'array' && allowedArrayTypes.includes(items));
 }
 
-export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null, projectKeys: string[]): FilterField[] {
+export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null, projectKeys: string[], issueStatuses: Status[] | null, issueTypes: string[]): FilterField[] {
     const fields = getCustomFieldsForProjects(metadata, projectKeys).filter(isValidFieldForFilter);
     const selectFields = fields.filter((field) => Boolean(field.allowedValues && field.allowedValues.length)) as (SelectField & FieldWithInfo)[];
     const populatedFields = selectFields.map((field) => {
@@ -221,6 +224,26 @@ export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null,
             schema: epicLinkField.schema,
             values: [],
             issueTypes: epicLinkField.validIssueTypes,
+        } as FilterField);
+    }
+
+    if (issueStatuses) {
+        result.push({
+            key: 'status',
+            name: 'Status',
+            schema: {
+                type: 'array',
+            },
+            values: issueStatuses.map((value) => ({
+                label: value.name,
+                value: value.id,
+            })),
+            issueTypes: issueTypes.map((type) => {
+                return {
+                    id: type,
+                    name: type,
+                };
+            }),
         } as FilterField);
     }
 

--- a/webapp/src/utils/jira_issue_metadata.tsx
+++ b/webapp/src/utils/jira_issue_metadata.tsx
@@ -229,7 +229,7 @@ export function getCustomFieldFiltersForProjects(metadata: IssueMetadata | null,
 
     if (issueStatuses) {
         result.push({
-            key: 'status',
+            key: FIELD_KEY_STATUS,
             name: 'Status',
             schema: {
                 type: 'array',


### PR DESCRIPTION
- Moved the issue status field into filters section of modal
- Conditionally removed the "Empty" and "Include all" options.

![image](https://github.com/Brightscout/mattermost-plugin-jira/assets/55234496/df54701d-bbea-4645-9627-e4223f600989)
