### PR TITLE
[MM-183] Add lock to avoid race conditions while performing operations on autolink

### DIFF
--- a/server/kv.go
+++ b/server/kv.go
@@ -568,13 +568,13 @@ func UpdateInstances(store InstanceStore, updatef func(instances *Instances) err
 
 // MigrateV2Instances migrates instance record(s) from the V2 data model.
 //
-// - v2keyKnownJiraInstances ("known_jira_instances") was stored as a
-//   map[string]string (InstanceID->Type), needs to be stored as Instances.
-//   https://github.com/mattermost/mattermost-plugin-jira/blob/885efe8eb70c92bcea64d1ced6e67710eda77b6e/server/kv.go#L375
-// - v2keyCurrentJIRAInstance ("current_jira_instance") stored an Instance; will
-//   be used to set the default instance.
-// - The instances themselves should be forward-compatible, including
-// 	 CurrentInstance.
+//   - v2keyKnownJiraInstances ("known_jira_instances") was stored as a
+//     map[string]string (InstanceID->Type), needs to be stored as Instances.
+//     https://github.com/mattermost/mattermost-plugin-jira/blob/885efe8eb70c92bcea64d1ced6e67710eda77b6e/server/kv.go#L375
+//   - v2keyCurrentJIRAInstance ("current_jira_instance") stored an Instance; will
+//     be used to set the default instance.
+//   - The instances themselves should be forward-compatible, including
+//     CurrentInstance.
 func MigrateV2Instances(p *Plugin) (*Instances, error) {
 	// Check if V3 instances exist and return them if found
 	instances, err := p.instanceStore.LoadInstances()
@@ -646,7 +646,7 @@ func MigrateV2Instances(p *Plugin) (*Instances, error) {
 	return instances, nil
 }
 
-//  MigrateV3ToV2 performs necessary migrations when reverting from V3 to  V2
+// MigrateV3ToV2 performs necessary migrations when reverting from V3 to  V2
 func MigrateV3ToV2(p *Plugin) string {
 	// migrate V3 instances to v2
 	v2Instances, msg := MigrateV3InstancesToV2(p)
@@ -675,10 +675,10 @@ func MigrateV3ToV2(p *Plugin) string {
 
 // MigrateV3InstancesToV2 migrates instance record(s) from the V3 data model.
 //
-// - v3 instances need to be stored as v2keyKnownJiraInstances
-//   (known_jira_instances)  map[string]string (InstanceID->Type),
-// - v2keyCurrentJIRAInstance ("current_jira_instance") stored an Instance; will
-//   be used to set the default instance.
+//   - v3 instances need to be stored as v2keyKnownJiraInstances
+//     (known_jira_instances)  map[string]string (InstanceID->Type),
+//   - v2keyCurrentJIRAInstance ("current_jira_instance") stored an Instance; will
+//     be used to set the default instance.
 func MigrateV3InstancesToV2(p *Plugin) (JiraV2Instances, string) {
 	v3instances, err := p.instanceStore.LoadInstances()
 	if err != nil {


### PR DESCRIPTION
#### Summary

- Add cluster mutex lock to avoid race conditions while reading/deleting/creating the autolinks.
- Solves comment: https://github.com/Brightscout/mattermost-plugin-jira/pull/45#discussion_r1470504065