### PR TITLE
[MM-996]: removed jwt instance from setup autocomplete

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -176,7 +176,6 @@ func createInstanceCommand(optInstance bool) *model.AutocompleteData {
 	jiraTypes := []model.AutocompleteListItem{
 		{HelpText: "Jira Server or Datacenter", Item: "server"},
 		{HelpText: "Jira Cloud OAuth 2.0 (atlassian.net)", Item: "cloud-oauth"},
-		{HelpText: "Jira Cloud (atlassian.net) (Deprecated. Please use cloud-oauth instead.)", Item: "cloud"},
 	}
 
 	install := model.NewAutocompleteData(


### PR DESCRIPTION
#### Summary
Remove "cloud" JWT instance type from install paths

##### Exisiting
![Screenshot from 2024-06-28 21-06-15](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/6979343e-5ae5-476d-9b78-ea502165bc91)


##### Updated
![Screenshot from 2024-06-28 20-58-42](https://github.com/mattermost/mattermost-plugin-jira/assets/90389917/e0a2cbbe-8633-4f13-ac61-439914df088d)


#### Issue
Fixes https://github.com/mattermost/mattermost-plugin-jira/issues/996

