### PR TITLE
[MM-1096]: Fixed improper markdown for Jira comments received as a subscription in mattermost

### DIFF
--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -337,7 +337,7 @@ func preProcessText(jiraMarkdownString string) string {
 	var counter int
 	var lastLineWasNumberedList bool
 	var result []string
-	lines := strings.Split(comment, "\n")
+	lines := strings.Split(jiraMarkdownString, "\n")
 	for _, line := range lines {
 		if numberedListRegex.MatchString(line) {
 			if !lastLineWasNumberedList {

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -318,6 +318,11 @@ func quoteIssueComment(comment string) string {
 	return "> " + strings.ReplaceAll(comment, "\n", "\n> ")
 }
 
+// preProcessText processes the given comment string to apply various formatting transformations.
+// The purpose of the function is to convert the formatting provided by JIRA into the corresponding formatting supported by Mattermost.
+// This includes converting asterisks to bold, hyphens to strikethrough, JIRA-style headings to Markdown headings,
+// JIRA code blocks to inline code, numbered lists to Markdown lists, colored text to plain text, and JIRA links to Markdown links.
+// For more reference, please visit https://github.com/mattermost/mattermost-plugin-jira/issues/1096
 func preProcessText(comment string) string {
 	asteriskRegex := regexp.MustCompile(`\*(\w+)\*`)
 	hyphenRegex := regexp.MustCompile(`-(\w+)-`)
@@ -327,7 +332,7 @@ func preProcessText(comment string) string {
 	colouredTextRegex := regexp.MustCompile(`\{color:[^}]+\}(.*?)\{color\}`)
 	linkRegex := regexp.MustCompile(`\[(.*?)\|([^|\]]+)(?:\|([^|\]]+))?\]`)
 
-	// below code converts lines starting with "#" into a numbered list. It increments the counter if consecutive lines are numbered,
+	// the below code converts lines starting with "#" into a numbered list. It increments the counter if consecutive lines are numbered,
 	// otherwise resets it to 1. The "#" is replaced with the corresponding number and period. Non-numbered lines are added unchanged.
 	var counter int
 	var lastLineWasNumberedList bool
@@ -349,7 +354,7 @@ func preProcessText(comment string) string {
 	}
 	processedComment := strings.Join(result, "\n")
 
-	// below code converts links in the format "[text|url]" or "[text|url|optional]" to Markdown links. If the text is empty,
+	// the below code converts links in the format "[text|url]" or "[text|url|optional]" to Markdown links. If the text is empty,
 	// the URL is used for both the text and link. If the optional part is present, it's ignored. Unrecognized patterns remain unchanged.
 	processedComment = linkRegex.ReplaceAllStringFunc(processedComment, func(link string) string {
 		parts := linkRegex.FindStringSubmatch(link)

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -318,12 +318,12 @@ func quoteIssueComment(comment string) string {
 	return "> " + strings.ReplaceAll(comment, "\n", "\n> ")
 }
 
-// preProcessText processes the given comment string to apply various formatting transformations.
+// preProcessText processes the given string to apply various formatting transformations.
 // The purpose of the function is to convert the formatting provided by JIRA into the corresponding formatting supported by Mattermost.
 // This includes converting asterisks to bold, hyphens to strikethrough, JIRA-style headings to Markdown headings,
 // JIRA code blocks to inline code, numbered lists to Markdown lists, colored text to plain text, and JIRA links to Markdown links.
 // For more reference, please visit https://github.com/mattermost/mattermost-plugin-jira/issues/1096
-func preProcessText(comment string) string {
+func preProcessText(jiraMarkdownString string) string {
 	asteriskRegex := regexp.MustCompile(`\*(\w+)\*`)
 	hyphenRegex := regexp.MustCompile(`-(\w+)-`)
 	headingRegex := regexp.MustCompile(`(?m)^(h[1-6]\.)\s+`)

--- a/server/webhook_parser.go
+++ b/server/webhook_parser.go
@@ -487,7 +487,7 @@ func parseWebhookUpdatedDescription(jwh *JiraWebhook, from, to string) *webhook 
 	fromFmttd := "\n**From:** " + truncate(from, 500)
 	toFmttd := "\n**To:** " + truncate(to, 500)
 	wh.fieldInfo = webhookField{descriptionField, descriptionField, fromFmttd, toFmttd}
-	wh.text = jwh.mdIssueDescription()
+	wh.text = preProcessText(jwh.mdIssueDescription())
 	return wh
 }
 


### PR DESCRIPTION
### Description
- Corrected Markdown formatting for Jira comments received as subscriptions in Mattermost.
- Note that Mattermost does not support colored text in Markdown; any colored text from Jira comments will be displayed as plain text in Mattermost.

**Important:** This PR employs regular expressions to identify and replace various Markdown elements. If these identifiers are present exactly as written in the comment, they will be interpreted as Markdown by Mattermost. However, the likelihood of this occurring is minimal.

### Screenshots

#### Jira Comment
![jira text](https://github.com/user-attachments/assets/86925835-475c-458b-a6ff-95f2a95c05b8)

#### Previous Mattermost Subscription Notification
![old mattermost text](https://github.com/user-attachments/assets/261f1361-9db7-46f7-b79a-ae8d82288fb6)

#### Updated Mattermost Subscription Notification
![mattermost text](https://github.com/user-attachments/assets/d03f2c43-a439-48a7-8356-ce41f45f2367)
