### PR TITLE
MM-571: Fixed the issue of receiving Jira subscription after the channel is archived

### DIFF
--- a/server/webhook.go
+++ b/server/webhook.go
@@ -67,16 +67,6 @@ func (wh webhook) PostToChannel(p *Plugin, instanceID types.ID, channelID, fromU
 		wh.headline = fmt.Sprintf("%s\nSubscription: **%s**", wh.headline, subscriptionName)
 	}
 
-	channel, nErr := p.API.GetChannel(channelID)
-	if nErr != nil {
-		p.client.Log.Warn("error occurred while getting the channel details while posting the webhook event", "ChannelID", channelID, "Error", nErr.DetailedError)
-		return nil, http.StatusInternalServerError, errors.Errorf("error getting channel details")
-	}
-
-	if channel.DeleteAt > 0 {
-		return nil, http.StatusBadRequest, errors.Errorf("archived channel")
-	}
-
 	post := &model.Post{
 		ChannelId: channelID,
 		UserId:    fromUserID,

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -69,7 +69,7 @@ func (wh webhook) PostToChannel(p *Plugin, instanceID types.ID, channelID, fromU
 
 	channel, nErr := p.API.GetChannel(channelID)
 	if nErr != nil {
-		p.client.Log.Warn("error occured while getting the channel details while posting the webhook event", "ChannelID", channelID, "Error", nErr.DetailedError)
+		p.client.Log.Warn("error occurred while getting the channel details while posting the webhook event", "ChannelID", channelID, "Error", nErr.DetailedError)
 		return nil, http.StatusInternalServerError, errors.Errorf("error getting channel details")
 	}
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -67,6 +67,16 @@ func (wh webhook) PostToChannel(p *Plugin, instanceID types.ID, channelID, fromU
 		wh.headline = fmt.Sprintf("%s\nSubscription: **%s**", wh.headline, subscriptionName)
 	}
 
+	channel, nErr := p.API.GetChannel(channelID)
+	if nErr != nil {
+		p.client.Log.Warn("error occured while getting the channel details while posting the webhook event", "ChannelID", channelID, "Error", nErr.DetailedError)
+		return nil, http.StatusInternalServerError, errors.Errorf("error getting channel details")
+	}
+
+	if channel.DeleteAt > 0 {
+		return nil, http.StatusBadRequest, errors.Errorf("archived channel")
+	}
+
 	post := &model.Post{
 		ChannelId: channelID,
 		UserId:    fromUserID,

--- a/server/webhook_worker.go
+++ b/server/webhook_worker.go
@@ -62,6 +62,16 @@ func (ww webhookWorker) process(msg *webhookMessage) (err error) {
 
 	botUserID := ww.p.getUserID()
 	for _, channelSubscribed := range channelsSubscribed {
+		channel, nErr := ww.p.API.GetChannel(channelSubscribed.ChannelID)
+		if nErr != nil {
+			ww.p.client.Log.Warn("error occurred while getting the channel details while posting the webhook event", "ChannelID", channelSubscribed.ChannelID, "Error", nErr.DetailedError)
+			return errors.Errorf(nErr.DetailedError)
+		}
+
+		if channel.DeleteAt > 0 {
+			continue
+		}
+
 		if _, _, err1 := wh.PostToChannel(ww.p, msg.InstanceID, channelSubscribed.ChannelID, botUserID, channelSubscribed.Name); err1 != nil {
 			ww.p.errorf("WebhookWorker id: %d, error posting to channel, err: %v", ww.id, err1)
 		}

--- a/server/webhook_worker.go
+++ b/server/webhook_worker.go
@@ -62,10 +62,10 @@ func (ww webhookWorker) process(msg *webhookMessage) (err error) {
 
 	botUserID := ww.p.getUserID()
 	for _, channelSubscribed := range channelsSubscribed {
-		channel, nErr := ww.p.API.GetChannel(channelSubscribed.ChannelID)
-		if nErr != nil {
-			ww.p.client.Log.Warn("error occurred while getting the channel details while posting the webhook event", "ChannelID", channelSubscribed.ChannelID, "Error", nErr.DetailedError)
-			return errors.Errorf(nErr.DetailedError)
+		channel, err := ww.p.client.Channel.Get(channelSubscribed.ChannelID)
+		if err != nil {
+			ww.p.client.Log.Warn("Error occurred while getting the channel details while posting the webhook event", "ChannelID", channelSubscribed.ChannelID, "Error", err.Error())
+			return err
 		}
 
 		if channel.DeleteAt > 0 {


### PR DESCRIPTION
### Summary
- Fixed the issue of receiving the Jira subscription after the channel is archived

### How to Test
- Create a subscription in a channel and check if the subscription is working
- Archive the channel
- Try sending more subscription events
- Unarchive the channel
#### Current behaviour
- Subscription event notification are received after the channel is archived
#### Updated behaviour
- No subscription event notification received after the channel is archived